### PR TITLE
Include LICENSE in source package

### DIFF
--- a/MANIFEST.IN
+++ b/MANIFEST.IN
@@ -1,0 +1,1 @@
+include LICENSE

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,8 @@ setuptools.setup(
     packages=['cmdline_provenance'],
     zip_safe=False,
     install_requires=['datetime', 'gitpython'],
+    license='MIT License',
+    include_package_data=True,
     classifiers=(
         'Programming Language :: Python :: 3',
         'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
In order to be able to install this with conda, we have to include the LICENSE with the source distribution. This will do it (more info https://stackoverflow.com/questions/1612733/including-non-python-files-with-setup-py).